### PR TITLE
reduxを使わずにタスクリストの更新処理を書いてみる

### DIFF
--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -10,9 +10,10 @@ const StyledTaskBlock = styled('div')`
 
 type Props = {
   task: TaskType;
+  updateState: (isTaskListUpdated: boolean) => void;
 }
 
-const TaskBlock: React.FC<Props> = ({task}) => {
+const TaskBlock: React.FC<Props> = ({task, updateState}: Props) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const onChange = () => {
     console.log("task status changed");
@@ -21,6 +22,7 @@ const TaskBlock: React.FC<Props> = ({task}) => {
   const onTaskDelete = (taskId: number) => {
     console.log("task deleted");
     deleteTask(taskId);
+    updateState(true);
   }
 
   const changeEditMode = () => {

--- a/src/app/components/TaskForm.tsx
+++ b/src/app/components/TaskForm.tsx
@@ -2,7 +2,11 @@
 import accessDB from "../services/indexedDB/accessDB";
 import addTask from "../services/indexedDB/addTask";
 
-const TaskForm = () => {
+type Props = {
+  onSetTask: (isTaskListUpdated: boolean) => void;
+}
+
+const TaskForm = ({onSetTask}: Props) => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -17,6 +21,7 @@ const TaskForm = () => {
         return;
       }
       addTask(DBOpenRequest, taskName);
+      onSetTask(true);
     }
   }
   

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -4,8 +4,12 @@ import TaskBlock from "./TaskBlock";
 import { TaskType } from "../types/TaskType";
 import getActiveTasks from "../services/indexedDB/getActiveTasks";
 
+type Props = {
+  onTaskListUpdated: boolean;
+  updateState: (isTaskListUpdated: boolean) => void;
+}
 
-const TaskList = () => {
+const TaskList = ({onTaskListUpdated, updateState}: Props) => {
   const [tasks, setTasks] = useState<TaskType[]>([]);
 
   useEffect(() => {
@@ -17,7 +21,8 @@ const TaskList = () => {
         console.error(err);
       }
     })();
-  }, [])
+    updateState(false)
+  }, [onTaskListUpdated, updateState])
 
   useEffect(() => {
     console.log(tasks);
@@ -27,7 +32,7 @@ const TaskList = () => {
     <div>
       {tasks.map((task) => (
         <div key={task.id}>
-          <TaskBlock task={task} />
+          <TaskBlock task={task} updateState={updateState}  />
         </div>
       ))}
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,15 @@
+'use client'
+import { useState } from 'react';
 import TaskForm from './components/TaskForm'
 import TaskList from './components/TaskList'
 
 export default function Home() {
+  const [isTaskListUpdated, setIsTaskListUpdated] = useState(false);
+  
   return (
     <>
-      <TaskForm/>
-      <TaskList />
+      <TaskForm onSetTask={setIsTaskListUpdated}/>
+      <TaskList onTaskListUpdated={isTaskListUpdated} updateState={setIsTaskListUpdated} />
     </>
   )
 }


### PR DESCRIPTION
## やったこと

- プロジェクトから移すに当たって、本当にredux-toolkitの導入が必要かどうかを検討するために、redux-toolkitを使わない実装にしてみる

## とくに見て欲しいところ

- redux-toolkitを使わない実装にするとpage.tsxからisTaskListUpdatedとsetIsTaskListUpdatedをバケツリレーで渡していかないといけない。
- reduxに限らず、何かの状態管理ライブラリが必要そうということがわかった。recoilを使ってみる？
- いくつか状態管理ライブラリがあるので、比較検討してみる

## 動作確認したこと

- リロードしなくても、タスクの追加をすると、タスクリストが更新されて追加したタスクが表示されること
- タスクのdeleteボタンを押すと、タスクが消えること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced real-time updates for task list upon task addition or deletion.
- **Refactor**
	- Enhanced communication between components for better state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->