### PR TITLE
useContextを使って状態管理をする

### DIFF
--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 import { TaskType } from "../types/TaskType";
 import deleteTask from "../services/indexedDB/deleteTask";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 
 const StyledTaskBlock = styled('div')`
   display: flex;
@@ -10,11 +11,11 @@ const StyledTaskBlock = styled('div')`
 
 type Props = {
   task: TaskType;
-  updateState: (isTaskListUpdated: boolean) => void;
 }
 
-const TaskBlock: React.FC<Props> = ({task, updateState}: Props) => {
+const TaskBlock: React.FC<Props> = ({task}: Props) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
+  const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
   const onChange = () => {
     console.log("task status changed");
   }
@@ -22,7 +23,7 @@ const TaskBlock: React.FC<Props> = ({task, updateState}: Props) => {
   const onTaskDelete = (taskId: number) => {
     console.log("task deleted");
     deleteTask(taskId);
-    updateState(true);
+    setIsTaskListUpdated(true);
   }
 
   const changeEditMode = () => {

--- a/src/app/components/TaskForm.tsx
+++ b/src/app/components/TaskForm.tsx
@@ -18,7 +18,8 @@ const TaskForm = () => {
     DBOpenRequest.onsuccess = () => {
       const taskName = formData.get("taskName");
       if (!taskName) {
-        console.log("no task name")
+        // TODO: エラーメッセージをFormの下に表示する
+        console.error("no task name")
         return;
       }
       addTask(DBOpenRequest, taskName);

--- a/src/app/components/TaskForm.tsx
+++ b/src/app/components/TaskForm.tsx
@@ -1,12 +1,13 @@
 'use client'
+import { useContext } from "react";
 import accessDB from "../services/indexedDB/accessDB";
 import addTask from "../services/indexedDB/addTask";
+import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 
-type Props = {
-  onSetTask: (isTaskListUpdated: boolean) => void;
-}
 
-const TaskForm = ({onSetTask}: Props) => {
+const TaskForm = () => {
+  const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -21,7 +22,7 @@ const TaskForm = ({onSetTask}: Props) => {
         return;
       }
       addTask(DBOpenRequest, taskName);
-      onSetTask(true);
+      setIsTaskListUpdated(true);
     }
   }
   

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -1,16 +1,14 @@
 'use client'
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import TaskBlock from "./TaskBlock";
 import { TaskType } from "../types/TaskType";
 import getActiveTasks from "../services/indexedDB/getActiveTasks";
+import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 
-type Props = {
-  onTaskListUpdated: boolean;
-  updateState: (isTaskListUpdated: boolean) => void;
-}
 
-const TaskList = ({onTaskListUpdated, updateState}: Props) => {
+const TaskList = () => {
   const [tasks, setTasks] = useState<TaskType[]>([]);
+  const {isTaskListUpdated, setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
 
   useEffect(() => {
     (async () => {
@@ -21,8 +19,8 @@ const TaskList = ({onTaskListUpdated, updateState}: Props) => {
         console.error(err);
       }
     })();
-    updateState(false)
-  }, [onTaskListUpdated, updateState])
+    setIsTaskListUpdated(false)
+  }, [isTaskListUpdated, setIsTaskListUpdated])
 
   useEffect(() => {
     console.log(tasks);
@@ -32,7 +30,7 @@ const TaskList = ({onTaskListUpdated, updateState}: Props) => {
     <div>
       {tasks.map((task) => (
         <div key={task.id}>
-          <TaskBlock task={task} updateState={updateState}  />
+          <TaskBlock task={task} />
         </div>
       ))}
     </div>

--- a/src/app/components/TaskList.tsx
+++ b/src/app/components/TaskList.tsx
@@ -22,10 +22,6 @@ const TaskList = () => {
     setIsTaskListUpdated(false)
   }, [isTaskListUpdated, setIsTaskListUpdated])
 
-  useEffect(() => {
-    console.log(tasks);
-  }, [tasks])
-
   return (
     <div>
       {tasks.map((task) => (

--- a/src/app/context/TaskListUpdatedContext.ts
+++ b/src/app/context/TaskListUpdatedContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+type TaskListUpdatedContextType = {
+  isTaskListUpdated: boolean,
+  setIsTaskListUpdated: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export const TaskListUpdatedContext = createContext<TaskListUpdatedContextType>({isTaskListUpdated: false,
+  setIsTaskListUpdated: ()=> {}});

--- a/src/app/context/TaskListUpdatedContext.ts
+++ b/src/app/context/TaskListUpdatedContext.ts
@@ -6,4 +6,4 @@ type TaskListUpdatedContextType = {
 }
 
 export const TaskListUpdatedContext = createContext<TaskListUpdatedContextType>({isTaskListUpdated: false,
-  setIsTaskListUpdated: ()=> {}});
+  setIsTaskListUpdated: ()=> { console.warn('setIsTaskListUpdated was called without a context provider'); }});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,14 +2,15 @@
 import { useState } from 'react';
 import TaskForm from './components/TaskForm'
 import TaskList from './components/TaskList'
+import { TaskListUpdatedContext } from './context/TaskListUpdatedContext';
 
 export default function Home() {
   const [isTaskListUpdated, setIsTaskListUpdated] = useState(false);
   
   return (
-    <>
-      <TaskForm onSetTask={setIsTaskListUpdated}/>
-      <TaskList onTaskListUpdated={isTaskListUpdated} updateState={setIsTaskListUpdated} />
-    </>
+    <TaskListUpdatedContext.Provider value={{isTaskListUpdated, setIsTaskListUpdated}}>
+      <TaskForm />
+      <TaskList />
+    </TaskListUpdatedContext.Provider>
   )
 }


### PR DESCRIPTION
## やったこと

- useContextを使って状態管理をする実装方法に変更をしました

## とくに見て欲しいところ

- createContextを呼び出す箇所は、context/TaskListUpdatedContext.tsに置きました

## 動作確認したこと

- タスクの登録と削除が意図通りに行えること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `TaskListUpdatedContext` to manage task list updates across components.

- **Refactor**
  - Replaced prop drilling with context for task list state management in `TaskBlock`, `TaskForm`, and `TaskList` components.
  - Removed redundant props and updated components to use the new context.

- **Documentation**
  - Added comments to clarify the use of `TaskListUpdatedContext` in state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->