### PR TITLE
タスクの着手時間を計測するボタンを追加

### DIFF
--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -6,6 +6,7 @@ import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 import updateTaskStatus from "../services/indexedDB/updateTaskStatus";
 import updateTaskName from "../services/indexedDB/updateTaskName";
 import accessDB from "../services/indexedDB/accessDB";
+import { TaskTimerContext } from "../context/TaskTimerContextType";
 
 const StyledTaskBlock = styled('div')`
   display: flex;
@@ -19,6 +20,7 @@ type Props = {
 const TaskBlock: React.FC<Props> = ({task}: Props) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
+  const {currentTaskId, setCurrentTaskId, isRunning, setIsRunning} = useContext(TaskTimerContext);
   const onChangeStatus = (taskId: number) => {
     console.log("task status changed");
     updateTaskStatus(taskId);
@@ -34,6 +36,11 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
   const changeEditMode = () => {
     console.log("changeEditMode")
     setIsEditMode(!isEditMode);
+  }
+
+  const onTaskStart = (taskId: number) => {
+    setIsRunning(true);
+    setCurrentTaskId(taskId);
   }
 
   const onUpdateTaskName = (e: React.FormEvent<HTMLFormElement>, taskId: number) => {
@@ -68,6 +75,8 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
           <p>Status:{task.status}</p>
           <button onClick={() => {onTaskDelete(task.id)}}>delete</button>
           <button onClick={() => {changeEditMode()}}>Edit</button>
+          {task.id !== currentTaskId && (<button onClick={() => onTaskStart(task.id)}>Start</button>)}
+          {task.id === currentTaskId && isRunning && (<p>着手中</p>)}
         </StyledTaskBlock>
       ): (
         <StyledTaskBlock>

--- a/src/app/components/TaskTimer.tsx
+++ b/src/app/components/TaskTimer.tsx
@@ -1,32 +1,32 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect } from "react";
 import { TaskTimerContext } from "../context/TaskTimerContextType";
 
 const TaskTimer = () => {
-  const [time, setTime] = useState(0);
-  const {isRunning, setIsRunning} = useContext(TaskTimerContext);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const {isRunning, setIsRunning, setCurrentTaskId, elapsedTime, setElapsedTime} = useContext(TaskTimerContext);
 
-  const handleStart = () => {
-    setIsRunning(true);
-    intervalRef.current = setInterval(() => {
-      setTime(prevTime => prevTime + 1000);
-    }, 1000);
-  }
+  useEffect(() => {
+    if(isRunning) {
+      const interval = setInterval(() => {
+        setElapsedTime(prevTime => prevTime + 1000);
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [isRunning, setElapsedTime])
 
   const handlePause = () => {
-    clearInterval(intervalRef.current as NodeJS.Timeout);
+    setCurrentTaskId(null);
     setIsRunning(false);
   }
 
-  const seconds = `0${Math.floor(time / 1000) % 60}`.slice(-2);
-  const minutes = `0${Math.floor(time / 60000) % 60}`.slice(-2);
-  const hours = `0${Math.floor(time / 3600000)}`.slice(-2);
+  const seconds = `0${Math.floor(elapsedTime / 1000) % 60}`.slice(-2);
+  const minutes = `0${Math.floor(elapsedTime / 60000) % 60}`.slice(-2);
+  const hours = `0${Math.floor(elapsedTime / 3600000)}`.slice(-2);
 
   return (
     <div>
       <h1>Task Timer</h1>
       <p>{hours}:{minutes}:{seconds}</p>
-      {isRunning ? (<button onClick={handlePause}>Pause</button>):(<button onClick={handleStart}>Start</button>)}
+      {isRunning && (<button onClick={handlePause}>Pause</button>)}
     </div>
   )
 }

--- a/src/app/context/TaskTimerContextType.ts
+++ b/src/app/context/TaskTimerContextType.ts
@@ -1,0 +1,19 @@
+import {createContext} from "react";
+
+type TaskTimerContextType = {
+  currentTaskId: number | null,
+  setCurrentTaskId: React.Dispatch<React.SetStateAction<number | null>>, 
+  isRunning: boolean;
+  setIsRunning: React.Dispatch<React.SetStateAction<boolean>>;
+  elapsedTime: number;
+  setElapsedTime: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export const TaskTimerContext = createContext<TaskTimerContextType>({
+  currentTaskId: null,
+  setCurrentTaskId: ()=> { console.warn('setCurrentTaskName was called without a context provider'); },
+  isRunning: false,
+  setIsRunning: ()=> { console.warn('setIsRunning was called without a context provider'); },
+  elapsedTime: 0,
+  setElapsedTime: ()=> { console.warn('setElapsedTime was called without a context provider'); }
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,15 +2,23 @@
 import { useState } from 'react';
 import TaskForm from './components/TaskForm'
 import TaskList from './components/TaskList'
+import TaskTimer from './components/TaskTimer';
 import { TaskListUpdatedContext } from './context/TaskListUpdatedContext';
+import { TaskTimerContext } from './context/TaskTimerContextType';
 
 export default function Home() {
   const [isTaskListUpdated, setIsTaskListUpdated] = useState(false);
+  const [currentTaskId, setCurrentTaskId] = useState<number | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [elapsedTime, setElapsedTime] = useState(0);
   
   return (
     <TaskListUpdatedContext.Provider value={{isTaskListUpdated, setIsTaskListUpdated}}>
-      <TaskForm />
-      <TaskList />
+      <TaskTimerContext.Provider value={{currentTaskId, setCurrentTaskId, isRunning, setIsRunning, elapsedTime, setElapsedTime}}>
+        <TaskTimer />
+        <TaskForm />
+        <TaskList />
+      </TaskTimerContext.Provider>
     </TaskListUpdatedContext.Provider>
   )
 }


### PR DESCRIPTION
## やったこと

- タスクの着手時間を計測するボタンを追加

## とくに見て欲しいところ

- タスクブロックに、タスク着手を開始するためのボタンを追加
- 現状は、タイマーがスタートするだけで、時間の記録はされない。
- 別のPRでタスクの時間を記録する仕組みを作る

## 動作確認したこと

- ボタンを押すとタイマーが動作することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a task timer into the `TaskBlock` component with start functionality.
  - Implemented a global timer state using `TaskTimerContext` for task tracking.

- **Enhancements**
  - Improved timer management in `TaskTimer` component using context instead of local state.

- **Refactor**
  - Introduced `TaskTimerContextType` for type-safe context operations.

- **Documentation**
  - Updated `page.tsx` to include `TaskTimer` component and context provider setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->