### PR TITLE
タイマーを止めると、タスク一覧の経過時間が更新される

### DIFF
--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -44,6 +44,7 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
     setIsRunning(true);
     if(currentTaskId){
       updateTaskElapsedTime(currentTaskId, elapsedTime);
+      setIsTaskListUpdated(true);
     }
     setCurrentTaskId(taskId);
   }

--- a/src/app/components/TaskTimer.tsx
+++ b/src/app/components/TaskTimer.tsx
@@ -3,15 +3,18 @@ import { TaskTimerContext } from "../context/TaskTimerContextType";
 import getTask from "../services/indexedDB/getTask";
 import updateTaskElapsedTime from "../services/indexedDB/updateTaskElapsedTime";
 import convertMsTime from "../helper/convertMsTime";
+import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 
 const TaskTimer = () => {
   const {isRunning, setIsRunning, currentTaskId, setCurrentTaskId, elapsedTime, setElapsedTime} = useContext(TaskTimerContext);
   const [currentTaskName, setCurrentTaskName] = useState<string>("");
+  const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
 
   const handlePause = (taskId: number, time: number) => {
     updateTaskElapsedTime(taskId, time);
     setCurrentTaskId(null);
     setIsRunning(false);
+    setIsTaskListUpdated(true);
   }
 
   useEffect(() => {
@@ -53,3 +56,7 @@ const TaskTimer = () => {
 }
 
 export default TaskTimer;
+
+function setIsTaskListUpdated(arg0: boolean) {
+  throw new Error("Function not implemented.");
+}


### PR DESCRIPTION
## やったこと

- タイマーを止めると、タスク一覧の経過時間が更新される

## とくに見て欲しいところ

-

## 動作確認したこと

- タイマーを止めると、タスク一覧に表示される経過時間の表示が更新される


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the task list is refreshed when a new task is started.
  - Fixed the task timer to correctly update the task list status upon pausing a task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->