### PR TITLE
時間の計算方法を変更

### DIFF
--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -10,6 +10,7 @@ import convertMsTime from "../helper/convertMsTime";
 import updateTaskInfo from "../services/indexedDB/updateTaskName";
 import { Box, Button, Checkbox, Flex, IconButton, Input, Text } from "@chakra-ui/react";
 import { DeleteIcon, EditIcon, TimeIcon, CalendarIcon } from '@chakra-ui/icons'
+import updateTaskStartTime from "../services/indexedDB/updateTaskStartTime";
 
 
 type Props = {
@@ -39,6 +40,7 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
 
   const onTaskStart = (taskId: number) => {
     setIsRunning(true);
+    updateTaskStartTime(taskId, Date.now())
     if(currentTaskId){
       updateTaskElapsedTime(currentTaskId, elapsedTime);
       setIsTaskListUpdated(true);

--- a/src/app/components/TaskTimer.tsx
+++ b/src/app/components/TaskTimer.tsx
@@ -5,11 +5,14 @@ import updateTaskElapsedTime from "../services/indexedDB/updateTaskElapsedTime";
 import convertMsTime from "../helper/convertMsTime";
 import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { TaskType } from "../types/TaskType";
 
 const TaskTimer = () => {
   const {isRunning, setIsRunning, currentTaskId, setCurrentTaskId, elapsedTime, setElapsedTime} = useContext(TaskTimerContext);
+  const [currentTask, setCurrentTask] = useState<TaskType | null>(null);
   const [currentTaskName, setCurrentTaskName] = useState<string>("");
   const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
+
 
   const handlePause = (taskId: number, time: number) => {
     updateTaskElapsedTime(taskId, time);
@@ -19,19 +22,22 @@ const TaskTimer = () => {
   }
 
   useEffect(() => {
-    if(isRunning) {
+    if(isRunning && currentTask) {
       const interval = setInterval(() => {
-        setElapsedTime(prevTime => prevTime + 1000);
+        if(currentTask.start_at !== null){
+          setElapsedTime(Date.now() - currentTask.start_at + currentTask.elapsed_time);
+        }
       }, 1000);
       return () => clearInterval(interval);
     }
-  }, [isRunning, setElapsedTime]);
+  }, [currentTask, isRunning, setElapsedTime]);
 
   useEffect(() => {
     const getTaskInfo = (taskId: number) => {
       (async () => {
         try {
           const task = await getTask(taskId);
+          setCurrentTask(task);
           setCurrentTaskName(task.taskName);
           setElapsedTime(task.elapsed_time);
         } catch (err) {

--- a/src/app/services/indexedDB/addTask.ts
+++ b/src/app/services/indexedDB/addTask.ts
@@ -3,7 +3,7 @@ const addTask = (dbRequest: IDBOpenDBRequest, taskName: FormDataEntryValue) => {
   const transaction = db.transaction(["tasks"], "readwrite");
 
   const objectStore = transaction.objectStore("tasks");
-  const request = objectStore.add({taskName: taskName, status: "active", elapsed_time: 0, isDeleted: 0});
+  const request = objectStore.add({taskName: taskName, status: "active", elapsed_time: 0, isDeleted: 0, isCurrentDoing: 0});
   request.onsuccess = () => {
     console.log("task added");
   }

--- a/src/app/services/indexedDB/createDB.ts
+++ b/src/app/services/indexedDB/createDB.ts
@@ -4,9 +4,10 @@ const createDB = (dbRequest: IDBOpenDBRequest) => {
   const objectStore = db.createObjectStore('tasks', { keyPath: 'id', autoIncrement: true });
   objectStore.createIndex("taskName", "taskName", {unique: false});
   objectStore.createIndex("status", "status", {unique: false});
+  objectStore.createIndex("start_at", "start_at", {unique: false});
   objectStore.createIndex("elapsed_time", "elapsed_time", {unique: false});
+  objectStore.createIndex("isCurrentDoing", "isCurrentDoing", {unique: false});
   objectStore.createIndex("isDeleted", "isDeleted", {unique: false});
-
 
   objectStore.transaction.oncomplete = () => {
     console.log('create yakDB complete');

--- a/src/app/services/indexedDB/updateTaskStartTime.ts
+++ b/src/app/services/indexedDB/updateTaskStartTime.ts
@@ -1,0 +1,22 @@
+import accessDB from "./accessDB";
+
+const updateTaskStartTime = (taskId: number, time: number) => {
+  const DBOpenRequest = accessDB();
+
+  DBOpenRequest.onsuccess = () => {
+    const db = DBOpenRequest.result;
+    const objectStore = db.transaction(["tasks"], "readwrite").objectStore('tasks');
+    const objectStoreTaskRequest = objectStore.get(taskId);
+    objectStoreTaskRequest.onsuccess = () => {
+      const data = objectStoreTaskRequest.result;
+      data.start_at = time;
+      const updateTaskRequest = objectStore.put(data);
+
+      updateTaskRequest.onsuccess = () => {
+        console.log("task status updated");
+      }
+    }
+  }
+}
+
+export default updateTaskStartTime;

--- a/src/app/types/TaskType.ts
+++ b/src/app/types/TaskType.ts
@@ -3,7 +3,10 @@ export type TaskStatus = 'active' | 'completed';
 export type TaskType = {
   taskName: string;
   status: TaskStatus;
+  start_at: number | null;
   elapsed_time: number;
   deadline: string | null;
   id: number;
+  isDeleted: number;
+  isCurrentDoing: number;
 }


### PR DESCRIPTION
## やったこと

- 経過時間の計算方法を変更しました
  - バックグラウンドタブ状態になると、時間が正しく計測されない現象が起きていた
  - タスクタイマーのスタート時間と、現在時刻の差分を使う計測方法に変更

## とくに見て欲しいところ

-

## 動作確認したこと

- バックグラウンドタブ状態で5分計測できることを確認
