### PR TITLE
現在実行中のタスクの情報の管理方法を変更する

### DIFF
--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -10,8 +10,8 @@ import convertMsTime from "../helper/convertMsTime";
 import updateTaskInfo from "../services/indexedDB/updateTaskName";
 import { Box, Button, Checkbox, Flex, IconButton, Input, Text } from "@chakra-ui/react";
 import { DeleteIcon, EditIcon, TimeIcon, CalendarIcon } from '@chakra-ui/icons'
-import updateTaskStartTime from "../services/indexedDB/updateTaskStartTime";
-
+import getTask from "../services/indexedDB/getTask";
+import updateCurrentTask from "../services/indexedDB/updateCurrentTask";
 
 type Props = {
   task: TaskType;
@@ -20,7 +20,8 @@ type Props = {
 const TaskBlock: React.FC<Props> = ({task}: Props) => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
-  const {currentTaskId, setCurrentTaskId, isRunning, setIsRunning, elapsedTime} = useContext(TaskTimerContext);
+  const {currentTask, setCurrentTask, isRunning, setIsRunning, elapsedTime} = useContext(TaskTimerContext);
+  
   const onChangeStatus = (taskId: number) => {
     console.log("task status changed");
     updateTaskStatus(taskId);
@@ -38,14 +39,18 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
     setIsEditMode(!isEditMode);
   }
 
-  const onTaskStart = (taskId: number) => {
+  const onTaskStart = async (taskId: number) => {
+    console.log("task started");
+    updateCurrentTask(taskId);
+    // updateTaskStartTime(taskId, Date.now());
+    // TODO: エラーハンドリング
+    const task = await getTask(taskId);
     setIsRunning(true);
-    updateTaskStartTime(taskId, Date.now())
-    if(currentTaskId){
-      updateTaskElapsedTime(currentTaskId, elapsedTime);
+    if(currentTask){
+      updateTaskElapsedTime(currentTask.id, elapsedTime);
       setIsTaskListUpdated(true);
     }
-    setCurrentTaskId(taskId);
+    setCurrentTask(task);
   }
 
   const onUpdateTaskInfo = (e: React.FormEvent<HTMLFormElement>, taskId: number) => {
@@ -53,7 +58,6 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
 
     const form = e.currentTarget;
     const formData = new FormData(form);
-
     
     const DBOpenRequest = accessDB();
     DBOpenRequest.onsuccess = () => {
@@ -80,11 +84,12 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
               <Checkbox type="checkbox" onChange={() => {onChangeStatus(task.id)}} />
               <Box>
                 <Text>{task.taskName}</Text>
+                <p>{task.start_at}</p>
               </Box>
             </Flex>
             <Flex align="center" gap='3'>
               <IconButton aria-label="Edit Task" icon={<EditIcon />} onClick={() => {changeEditMode()}}></IconButton>
-              <IconButton aria-label="Task Timer" icon={<TimeIcon />} onClick={() => onTaskStart(task.id)} isDisabled={task.id === currentTaskId && isRunning}></IconButton>
+              <IconButton aria-label="Task Timer" icon={<TimeIcon />} onClick={() => onTaskStart(task.id)} isDisabled={isRunning && currentTask !== null && currentTask.id === task.id }></IconButton>
               <IconButton aria-label="Delete Task" icon={<DeleteIcon />} onClick={() => {onTaskDelete(task.id)}}></IconButton>
             </Flex>
           </Flex>

--- a/src/app/components/TaskBlock.tsx
+++ b/src/app/components/TaskBlock.tsx
@@ -84,7 +84,6 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
               <Checkbox type="checkbox" onChange={() => {onChangeStatus(task.id)}} />
               <Box>
                 <Text>{task.taskName}</Text>
-                <p>{task.start_at}</p>
               </Box>
             </Flex>
             <Flex align="center" gap='3'>
@@ -94,7 +93,7 @@ const TaskBlock: React.FC<Props> = ({task}: Props) => {
             </Flex>
           </Flex>
           <Flex alignItems='center' gap='2'>
-            {task.elapsed_time !== 0 && (<Text><TimeIcon /> {convertMsTime(task.elapsed_time)}</Text>)}
+            {task.elapsedTime !== 0 && (<Text><TimeIcon /> {convertMsTime(task.elapsedTime)}</Text>)}
             {task.deadline && <Text><CalendarIcon />{task.deadline}</Text> }
           </Flex>
         </Box>

--- a/src/app/components/TaskTimer.tsx
+++ b/src/app/components/TaskTimer.tsx
@@ -1,22 +1,19 @@
 import { useContext, useEffect, useState } from "react";
 import { TaskTimerContext } from "../context/TaskTimerContextType";
-import getTask from "../services/indexedDB/getTask";
 import updateTaskElapsedTime from "../services/indexedDB/updateTaskElapsedTime";
 import convertMsTime from "../helper/convertMsTime";
 import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
-import { TaskType } from "../types/TaskType";
 
 const TaskTimer = () => {
-  const {isRunning, setIsRunning, currentTaskId, setCurrentTaskId, elapsedTime, setElapsedTime} = useContext(TaskTimerContext);
-  const [currentTask, setCurrentTask] = useState<TaskType | null>(null);
-  const [currentTaskName, setCurrentTaskName] = useState<string>("");
+  const {isRunning, setIsRunning, currentTask, setCurrentTask} = useContext(TaskTimerContext);
+  const [elapsedTime, setElapsedTime]=useState(0);
   const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
 
-
   const handlePause = (taskId: number, time: number) => {
+    // TODO: タスクを一時停止したら、currentTaskからデータを削除する
     updateTaskElapsedTime(taskId, time);
-    setCurrentTaskId(null);
+    setCurrentTask(null);
     setIsRunning(false);
     setIsTaskListUpdated(true);
   }
@@ -33,31 +30,16 @@ const TaskTimer = () => {
   }, [currentTask, isRunning, setElapsedTime]);
 
   useEffect(() => {
-    const getTaskInfo = (taskId: number) => {
-      (async () => {
-        try {
-          const task = await getTask(taskId);
-          setCurrentTask(task);
-          setCurrentTaskName(task.taskName);
-          setElapsedTime(task.elapsed_time);
-        } catch (err) {
-          console.error(err);
-        }
-      })();
-    }
-    
-    if(currentTaskId) {
-      getTaskInfo(currentTaskId);      
-    }
-  }, [currentTaskId, setElapsedTime]);
+    // TODO：初回読み込み時にcurrentTaskにデータがあったら、stateにcurrentTaskの情報を元にタスクのデータを入れる
+  }, []);
 
   return (
     <Box>
       <Flex align="center" justify='space-between'>
-        <Text>{currentTaskName ? (currentTaskName) : ("タスクを選択して計測を開始")}</Text>
+        <Text>{currentTask ? (currentTask.taskName) : ("タスクを選択して計測を開始")}</Text>
         <Flex align="center" gap={3}>
           <Text>{convertMsTime(elapsedTime)}</Text>
-          {isRunning && currentTaskId && (<Button onClick={() => handlePause(currentTaskId, elapsedTime)}>Pause</Button>)}
+          {isRunning && currentTask && (<Button onClick={() => handlePause(currentTask.id, elapsedTime)}>Pause</Button>)}
         </Flex>
       </Flex>
     </Box>

--- a/src/app/components/TaskTimer.tsx
+++ b/src/app/components/TaskTimer.tsx
@@ -4,34 +4,55 @@ import updateTaskElapsedTime from "../services/indexedDB/updateTaskElapsedTime";
 import convertMsTime from "../helper/convertMsTime";
 import { TaskListUpdatedContext } from "../context/TaskListUpdatedContext";
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import deleteCurrentTask from "../services/indexedDB/deleteCurrentTask";
+import getCurrentTask from "../services/indexedDB/getCurrentTask";
+import getTask from "../services/indexedDB/getTask";
 
 const TaskTimer = () => {
   const {isRunning, setIsRunning, currentTask, setCurrentTask} = useContext(TaskTimerContext);
   const [elapsedTime, setElapsedTime]=useState(0);
+  const [currentTaskStartedAt, setCurrentTaskStartedAt] = useState<number>(0);
   const {setIsTaskListUpdated} = useContext(TaskListUpdatedContext);
 
   const handlePause = (taskId: number, time: number) => {
-    // TODO: タスクを一時停止したら、currentTaskからデータを削除する
+    deleteCurrentTask();
     updateTaskElapsedTime(taskId, time);
     setCurrentTask(null);
+    setElapsedTime(0);
     setIsRunning(false);
     setIsTaskListUpdated(true);
   }
 
+  const getCurrentTaskStartedAt = async() => {
+    const currentTask = await getCurrentTask();
+    if(currentTask){
+      setCurrentTaskStartedAt(currentTask.startedAt);
+    }
+  };
+  getCurrentTaskStartedAt();
+
   useEffect(() => {
     if(isRunning && currentTask) {
-      const interval = setInterval(() => {
-        if(currentTask.start_at !== null){
-          setElapsedTime(Date.now() - currentTask.start_at + currentTask.elapsed_time);
+      const interval = setInterval(async () => {
+        if(currentTaskStartedAt){
+          setElapsedTime(Date.now() - currentTaskStartedAt + currentTask.elapsedTime);
         }
       }, 1000);
       return () => clearInterval(interval);
     }
-  }, [currentTask, isRunning, setElapsedTime]);
+  }, [currentTask, currentTaskStartedAt, isRunning, setElapsedTime]);
 
   useEffect(() => {
-    // TODO：初回読み込み時にcurrentTaskにデータがあったら、stateにcurrentTaskの情報を元にタスクのデータを入れる
-  }, []);
+    const getCurrentTaskFromDB = async() => {
+      const currentTaskInfo = await getCurrentTask();
+      if(currentTaskInfo) {
+        const currentTask = await getTask(currentTaskInfo.taskId);
+        setCurrentTask(currentTask);
+        setIsRunning(true);
+      }
+    }
+    getCurrentTaskFromDB();
+  }, [setCurrentTask, setIsRunning])
 
   return (
     <Box>

--- a/src/app/context/TaskTimerContextType.ts
+++ b/src/app/context/TaskTimerContextType.ts
@@ -1,8 +1,9 @@
 import {createContext} from "react";
+import { TaskType } from "../types/TaskType";
 
 type TaskTimerContextType = {
-  currentTaskId: number | null,
-  setCurrentTaskId: React.Dispatch<React.SetStateAction<number | null>>, 
+  currentTask: TaskType | null,
+  setCurrentTask: React.Dispatch<React.SetStateAction<TaskType | null>>,
   isRunning: boolean;
   setIsRunning: React.Dispatch<React.SetStateAction<boolean>>;
   elapsedTime: number;
@@ -10,8 +11,8 @@ type TaskTimerContextType = {
 }
 
 export const TaskTimerContext = createContext<TaskTimerContextType>({
-  currentTaskId: null,
-  setCurrentTaskId: ()=> { console.warn('setCurrentTaskName was called without a context provider'); },
+  currentTask: null,
+  setCurrentTask: ()=> { console.warn('setCurrentTask was called without a context provider'); },
   isRunning: false,
   setIsRunning: ()=> { console.warn('setIsRunning was called without a context provider'); },
   elapsedTime: 0,

--- a/src/app/services/indexedDB/addTask.ts
+++ b/src/app/services/indexedDB/addTask.ts
@@ -3,7 +3,7 @@ const addTask = (dbRequest: IDBOpenDBRequest, taskName: FormDataEntryValue) => {
   const transaction = db.transaction(["tasks"], "readwrite");
 
   const objectStore = transaction.objectStore("tasks");
-  const request = objectStore.add({taskName: taskName, status: "active", elapsed_time: 0, isDeleted: 0, isCurrentDoing: 0});
+  const request = objectStore.add({taskName: taskName, status: "active", elapsedTime: 0, isDeleted: 0, isCurrentDoing: 0});
   request.onsuccess = () => {
     console.log("task added");
   }

--- a/src/app/services/indexedDB/createDB.ts
+++ b/src/app/services/indexedDB/createDB.ts
@@ -1,15 +1,21 @@
 const createDB = (dbRequest: IDBOpenDBRequest) => {
   const db = dbRequest.result;
 
-  const objectStore = db.createObjectStore('tasks', { keyPath: 'id', autoIncrement: true });
-  objectStore.createIndex("taskName", "taskName", {unique: false});
-  objectStore.createIndex("status", "status", {unique: false});
-  objectStore.createIndex("start_at", "start_at", {unique: false});
-  objectStore.createIndex("elapsed_time", "elapsed_time", {unique: false});
-  objectStore.createIndex("isCurrentDoing", "isCurrentDoing", {unique: false});
-  objectStore.createIndex("isDeleted", "isDeleted", {unique: false});
+  const tasksStore = db.createObjectStore('tasks', { keyPath: 'id', autoIncrement: true });
+  tasksStore.createIndex("taskName", "taskName", {unique: false});
+  tasksStore.createIndex("status", "status", {unique: false});
+  tasksStore.createIndex("elapsedTime", "elapsedTime", {unique: false});
+  tasksStore.createIndex("isDeleted", "isDeleted", {unique: false});
+  
+  tasksStore.transaction.oncomplete = () => {
+    console.log('create yakDB complete');
+  }
+  
+  const currentTaskStore = db.createObjectStore('currentTask');
+  currentTaskStore.createIndex("taskId", "taskId", {unique: false});
+  currentTaskStore.createIndex("startedAt", "startedAt", {unique: false});
 
-  objectStore.transaction.oncomplete = () => {
+  currentTaskStore.transaction.oncomplete = () => {
     console.log('create yakDB complete');
   }
 }

--- a/src/app/services/indexedDB/deleteCurrentTask.ts
+++ b/src/app/services/indexedDB/deleteCurrentTask.ts
@@ -1,0 +1,17 @@
+import accessDB from "./accessDB";
+
+const deleteCurrentTask = () => {
+  const DBOpenRequest = accessDB();
+
+    DBOpenRequest.onsuccess = () => {
+      const db = DBOpenRequest.result;
+      const objectStore = db.transaction(["currentTask"], "readwrite").objectStore('currentTask');
+      const request = objectStore.delete("currentTask");
+      request.onsuccess = () => {
+        console.log("delete current task success")
+      }
+
+    }
+}
+
+export default deleteCurrentTask;

--- a/src/app/services/indexedDB/getCurrentTask.ts
+++ b/src/app/services/indexedDB/getCurrentTask.ts
@@ -1,13 +1,13 @@
 import accessDB from "./accessDB";
 
-const getCurrentTask = (taskId: number) => {
+const getCurrentTask = () => {
   return new Promise<{taskId: number, startedAt: number}>((resolve, reject) => {
     const DBOpenRequest = accessDB();
   
     DBOpenRequest.onsuccess = () => {
       const db = DBOpenRequest.result;
       const objectStore = db.transaction(["currentTask"], "readwrite").objectStore('currentTask');
-      const objectStoreTaskRequest = objectStore.get(taskId);
+      const objectStoreTaskRequest = objectStore.get("currentTask");
       objectStoreTaskRequest.onsuccess = () => {
         resolve(objectStoreTaskRequest.result);
         db.close();

--- a/src/app/services/indexedDB/getCurrentTask.ts
+++ b/src/app/services/indexedDB/getCurrentTask.ts
@@ -1,0 +1,27 @@
+import accessDB from "./accessDB";
+
+const getCurrentTask = (taskId: number) => {
+  return new Promise<{taskId: number, startedAt: number}>((resolve, reject) => {
+    const DBOpenRequest = accessDB();
+  
+    DBOpenRequest.onsuccess = () => {
+      const db = DBOpenRequest.result;
+      const objectStore = db.transaction(["currentTask"], "readwrite").objectStore('currentTask');
+      const objectStoreTaskRequest = objectStore.get(taskId);
+      objectStoreTaskRequest.onsuccess = () => {
+        resolve(objectStoreTaskRequest.result);
+        db.close();
+      }
+      objectStoreTaskRequest.onerror = (err) => {
+        reject(err);
+        db.close();
+      }
+    }
+
+    DBOpenRequest.onerror = (err) => {
+      reject(err);
+    }
+  })
+}
+
+export default getCurrentTask;

--- a/src/app/services/indexedDB/updateCurrentTask.ts
+++ b/src/app/services/indexedDB/updateCurrentTask.ts
@@ -1,0 +1,21 @@
+import accessDB from "./accessDB";
+
+const updateCurrentTask = (taskId: number) => {
+  const DBOpenRequest = accessDB();
+
+  DBOpenRequest.onsuccess = () => {
+    const db = DBOpenRequest.result;
+    const objectStore = db.transaction(["currentTask"], "readwrite").objectStore('currentTask');
+    const request = objectStore.put({taskId: taskId, startedAt: Date.now()}, 'currentTask');
+    request.onsuccess = () => {
+      console.log("currentTask status updated");   
+      db.close();
+    }
+    request.onerror = (err) => {
+      console.log(err);
+      db.close();
+    }
+  }
+}
+
+export default updateCurrentTask;

--- a/src/app/services/indexedDB/updateTaskElapsedTime.ts
+++ b/src/app/services/indexedDB/updateTaskElapsedTime.ts
@@ -9,7 +9,7 @@ const updateTaskElapsedTime = (taskId: number, time: number) => {
     const objectStoreTaskRequest = objectStore.get(taskId);
     objectStoreTaskRequest.onsuccess = () => {
       const data = objectStoreTaskRequest.result;
-      data.elapsed_time = time;
+      data.elapsedTime = time;
       const updateTaskRequest = objectStore.put(data);
 
       updateTaskRequest.onsuccess = () => {

--- a/src/app/types/TaskType.ts
+++ b/src/app/types/TaskType.ts
@@ -3,8 +3,7 @@ export type TaskStatus = 'active' | 'completed';
 export type TaskType = {
   taskName: string;
   status: TaskStatus;
-  start_at: number | null;
-  elapsed_time: number;
+  elapsedTime: number;
   deadline: string | null;
   id: number;
   isDeleted: number;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,19 +5,20 @@ import TaskList from '../app/components/TaskList'
 import TaskTimer from '../app/components/TaskTimer';
 import { TaskListUpdatedContext } from '../app/context/TaskListUpdatedContext';
 import { TaskTimerContext } from '../app/context/TaskTimerContextType';
-import { Button, Container, IconButton, useColorMode } from '@chakra-ui/react'
+import { Container, IconButton, useColorMode } from '@chakra-ui/react'
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+import { TaskType } from '@/app/types/TaskType';
 
 export default function Home() {
   const [isTaskListUpdated, setIsTaskListUpdated] = useState(false);
-  const [currentTaskId, setCurrentTaskId] = useState<number | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [elapsedTime, setElapsedTime] = useState(0);
+  const [currentTask, setCurrentTask] = useState<TaskType | null>(null);
   const { colorMode, toggleColorMode } = useColorMode()
   
   return (
     <TaskListUpdatedContext.Provider value={{isTaskListUpdated, setIsTaskListUpdated}}>
-      <TaskTimerContext.Provider value={{currentTaskId, setCurrentTaskId, isRunning, setIsRunning, elapsedTime, setElapsedTime}}>
+      <TaskTimerContext.Provider value={{currentTask, setCurrentTask, isRunning, setIsRunning, elapsedTime, setElapsedTime}}>
         <Container>
           <IconButton onClick={toggleColorMode} aria-label='Toggle dark mode' icon={colorMode === 'light' ? <SunIcon /> : <MoonIcon /> } />
           <TaskTimer />


### PR DESCRIPTION
## やったこと

- 現在実行中のタスクの情報を管理する方法を変更
  - 今までStateで情報を管理する方式にしていたが、その管理方法だとブラウザをリロードした時に実行中のタスクの情報が抜け落ちてしまう
  - indexedDBでcurrentTaskのidとstartedAtを持つテーブルを作り、実行中タスクのデータを永続化する処理を追加

## とくに見て欲しいところ

-

## 動作確認したこと


https://github.com/yuya-0928/yak-nextjs/assets/34731535/8e042392-7e9e-47d4-ba11-9ba94428aa64


